### PR TITLE
borwein_algorithm.cpp : fixed error. added header cstdio

### DIFF
--- a/Borwein's Algorithm/C++/borwein_algorithm.cpp
+++ b/Borwein's Algorithm/C++/borwein_algorithm.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstdio>
 #include <iostream>
 using namespace std;
 


### PR DESCRIPTION
If you compile the program (with ```g++```) you get this:  
> tempCodeRunnerFile.cpp:1:6: error: expected unqualified-id at end of input
 long double

I fixed the problem with adding the header ```cstdio```.  